### PR TITLE
Fix deliverables asset paths for image rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,14 +186,14 @@
             <div class="deliverables-grid">
                 <div class="deliverable-card">
                     <h3>Problem Process Flow</h3>
-                    <img src="Assets/CPF.PNG" alt="Problem Process Flow" class="deliverable-image">
+                    <img src="Assets/CPF.png" alt="Problem Process Flow" class="deliverable-image">
                     <a href="Assets/CPF.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
                 <div class="deliverable-card">
                     <h3>Solution Process Flow</h3>
-                    <img src="Assets/SPF.PNG" alt="Solution Process Flow" class="deliverable-image">
-                    <a href="Assets/SPF.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/SPF.png" alt="Solution Process Flow" class="deliverable-image">
+                    <a href="Assets/SPF.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
             </div>
 
@@ -202,14 +202,14 @@
             <div class="deliverables-grid">
                 <div class="deliverable-card">
                     <h3>Major Functional Components Diagram(MFCD)</h3>
-                    <img src="Assets/MFCD.PNG" alt="MFCD" class="deliverable-image">
-                    <a href="Assets/MFCD.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/MFCD.png" alt="MFCD" class="deliverable-image">
+                    <a href="Assets/MFCD.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
                 <div class="deliverable-card">
                     <h3>Database Schema</h3>
-                    <img src="Assets/DATABASE_SCHEMA.PNG" alt="Database Schema" class="deliverable-image">
-                    <a href="Assets/DATABASE_SCHEMA.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/DATABASE_SCHEMA.png" alt="Database Schema" class="deliverable-image">
+                    <a href="Assets/DATABASE_SCHEMA.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
             </div>
             <!-----ANALYSIS------>
@@ -224,106 +224,106 @@
 
                     <div class="deliverable-card">
                         <h3>User Risk</h3>
-                        <img src="Assets/USER_RISKS.PNG" alt="Risk Matrix" class="deliverable-image">
-                        <a href="Assets/USER_RISKS.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                        <img src="Assets/RISKS_SLIDES/USER_RISKS.png" alt="Risk Matrix" class="deliverable-image">
+                        <a href="Assets/RISKS_SLIDES/USER_RISKS.png" class="deliverable-link" target="_blank">View PDF</a>
                     </div>
     
                     <div class="deliverable-card">
                         <h3>Customer Risks</h3>
-                        <img src="Assets/CUSTOMER_RISKS.PNG" alt="Risk Matrix" class="deliverable-image">
-                        <a href="Assets/CUSTOMER_RISKS.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                        <img src="Assets/RISKS_SLIDES/CUSTOMER_RISKS.png" alt="Risk Matrix" class="deliverable-image">
+                        <a href="Assets/RISKS_SLIDES/CUSTOMER_RISKS.png" class="deliverable-link" target="_blank">View PDF</a>
                     </div>
     
                     <div class="deliverable-card">
                         <h3>Technical Risks</h3>
-                        <img src="Assets/TECHNICAL_RISKS.PNG" alt="Risk Matrix" class="deliverable-image">
-                        <a href="Assets/TECHNICAL_RISKS.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                        <img src="Assets/RISKS_SLIDES/TECHNICAL_RISKS.png" alt="Risk Matrix" class="deliverable-image">
+                        <a href="Assets/RISKS_SLIDES/TECHNICAL_RISKS.png" class="deliverable-link" target="_blank">View PDF</a>
                     </div>
     
                     <div class="deliverable-card">
                         <h3>Legal and Security Risks</h3>
-                        <img src="Assets/LEGAL_AND_SECURITY.PNG" alt="Risk Matrix" class="deliverable-image">
-                        <a href="Assets/LEGAL_AND_SECURITY.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                        <img src="Assets/RISKS_SLIDES/LEGAL_AND_SECURITY.png" alt="Risk Matrix" class="deliverable-image">
+                        <a href="Assets/RISKS_SLIDES/LEGAL_AND_SECURITY.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
 
 
                 <div class="deliverable-card">
                     <h3>Feature Table 1</h3>
-                    <img src="Assets/FT_1.PNG" alt="Feature Table" class="deliverable-image">
-                    <a href="Assets/FT_1.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/410_FEATURE_TABLES_OLD/FT_1.png" alt="Feature Table" class="deliverable-image">
+                    <a href="Assets/410_FEATURE_TABLES_OLD/FT_1.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
                 <div class="deliverable-card">
                     <h3>Feature Table 2</h3>
-                    <img src="Assets/FT_2.PNG" alt="Feature Table" class="deliverable-image">
-                    <a href="Assets/FT_2.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/410_FEATURE_TABLES_OLD/FT_2.png" alt="Feature Table" class="deliverable-image">
+                    <a href="Assets/410_FEATURE_TABLES_OLD/FT_2.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
                 <div class="deliverable-card">
                     <h3>Feature Table 3</h3>
-                    <img src="Assets/FT_3.PNG" alt="Feature Table" class="deliverable-image">
-                    <a href="Assets/FT_3.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/410_FEATURE_TABLES_OLD/FT_3.png" alt="Feature Table" class="deliverable-image">
+                    <a href="Assets/410_FEATURE_TABLES_OLD/FT_3.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
                 <div class="deliverable-card">
                     <h3>Feature Table 4</h3>
-                    <img src="Assets/FT_4.PNG" alt="Feature Table" class="deliverable-image">
-                    <a href="Assets/FT_4.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/410_FEATURE_TABLES_OLD/FT_4.png" alt="Feature Table" class="deliverable-image">
+                    <a href="Assets/410_FEATURE_TABLES_OLD/FT_4.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
                 <div class="deliverable-card">
                     <h3>Feature Table 5</h3>
-                    <img src="Assets/FT_5.PNG" alt="Feature Table" class="deliverable-image">
-                    <a href="Assets/FT_5.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/410_FEATURE_TABLES_OLD/FT_5.png" alt="Feature Table" class="deliverable-image">
+                    <a href="Assets/410_FEATURE_TABLES_OLD/FT_5.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
                 <div class="deliverable-card">
                     <h3>Feature Table 6</h3>
-                    <img src="Assets/FT_6.PNG" alt="Feature Table" class="deliverable-image">
-                    <a href="Assets/FT_6.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/410_FEATURE_TABLES_OLD/FT_6.png" alt="Feature Table" class="deliverable-image">
+                    <a href="Assets/410_FEATURE_TABLES_OLD/FT_6.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
                 <div class="deliverable-card">
                     <h3>Work Breakdown Structure 1</h3>
-                    <img src="Assets/WBS_1.PNG" alt="WBS Diagram" class="deliverable-image">
-                    <a href="Assets/WBS_1.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/WORK_BREAKDOWN_STRUCTURE/WBS_1.png" alt="WBS Diagram" class="deliverable-image">
+                    <a href="Assets/WORK_BREAKDOWN_STRUCTURE/WBS_1.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
                 <div class="deliverable-card">
                     <h3>Work Breakdown Structure 2</h3>
-                    <img src="Assets/WBS_2.PNG" alt="WBS Diagram" class="deliverable-image">
-                    <a href="Assets/WBS_2.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/WORK_BREAKDOWN_STRUCTURE/WBS_2.png" alt="WBS Diagram" class="deliverable-image">
+                    <a href="Assets/WORK_BREAKDOWN_STRUCTURE/WBS_2.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
                 <div class="deliverable-card">
                     <h3>Work Breakdown Structure 3</h3>
-                    <img src="Assets/WBS_3.PNG" alt="WBS Diagram" class="deliverable-image">
-                    <a href="Assets/WBS_3.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/WORK_BREAKDOWN_STRUCTURE/WBS_3.png" alt="WBS Diagram" class="deliverable-image">
+                    <a href="Assets/WORK_BREAKDOWN_STRUCTURE/WBS_3.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
                 <div class="deliverable-card">
                     <h3>Work Breakdown Structure(WBS) 4</h3>
-                    <img src="Assets/WBS_4.PNG" alt="WBS Diagram" class="deliverable-image">
-                    <a href="Assets/WBS_4.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/WORK_BREAKDOWN_STRUCTURE/WBS_4.png" alt="WBS Diagram" class="deliverable-image">
+                    <a href="Assets/WORK_BREAKDOWN_STRUCTURE/WBS_4.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
                 <div class="deliverable-card">
                     <h3>Work Breakdown Structure 5</h3>
-                    <img src="Assets/WBS_5.PNG" alt="WBS Diagram" class="deliverable-image">
-                    <a href="Assets/WBS_5.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/WORK_BREAKDOWN_STRUCTURE/WBS_5.png" alt="WBS Diagram" class="deliverable-image">
+                    <a href="Assets/WORK_BREAKDOWN_STRUCTURE/WBS_5.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
                 <div class="deliverable-card">
                     <h3>Work Breakdown Structure 6</h3>
-                    <img src="Assets/WBS_6.PNG" alt="WBS Diagram" class="deliverable-image">
-                    <a href="Assets/WBS_6.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/WORK_BREAKDOWN_STRUCTURE/WBS_6.png" alt="WBS Diagram" class="deliverable-image">
+                    <a href="Assets/WORK_BREAKDOWN_STRUCTURE/WBS_6.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
                 <div class="deliverable-card">
                     <h3>Work Breakdown Structure 7</h3>
-                    <img src="Assets/WBS_7.PNG" alt="WBS Diagram" class="deliverable-image">
-                    <a href="Assets/WBS_7.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/WORK_BREAKDOWN_STRUCTURE/WBS_7.png" alt="WBS Diagram" class="deliverable-image">
+                    <a href="Assets/WORK_BREAKDOWN_STRUCTURE/WBS_7.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
 
@@ -333,26 +333,26 @@
             <div class="deliverables-grid">
                 <div class="deliverable-card">
                     <h3>Algorithm 1</h3>
-                    <img src="Assets/ALGORITHM_1.PNG" alt="Algorithms" class="deliverable-image">
-                    <a href="Assets/ALGORITHM_1.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/ALGORITHMS/ALGORITHM_1.png" alt="Algorithms" class="deliverable-image">
+                    <a href="Assets/ALGORITHMS/ALGORITHM_1.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
                 <div class="deliverable-card">
                     <h3>Algorithm 2</h3>
-                    <img src="Assets/ALGORITHM_2.PNG" alt="Algorithms" class="deliverable-image">
-                    <a href="Assets/ALGORITHM_2.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/ALGORITHMS/ALGORITHM_2.png" alt="Algorithms" class="deliverable-image">
+                    <a href="Assets/ALGORITHMS/ALGORITHM_2.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
                 <div class="deliverable-card">
                     <h3>Algorithm 3</h3>
-                    <img src="Assets/ALGORITHM_3.PNG" alt="Algorithms" class="deliverable-image">
-                    <a href="Assets/ALGORITHM_3.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/ALGORITHMS/ALGORITHM_3.png" alt="Algorithms" class="deliverable-image">
+                    <a href="Assets/ALGORITHMS/ALGORITHM_3.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
 
                 <div class="deliverable-card">
                     <h3>Algorithm 4</h3>
-                    <img src="Assets/ALGORITHM_4.PNG" alt="Algorithms" class="deliverable-image">
-                    <a href="Assets/ALGORITHM_4.PNG" class="deliverable-link" target="_blank">View PDF</a>
+                    <img src="Assets/ALGORITHMS/ALGORITHM_4.png" alt="Algorithms" class="deliverable-image">
+                    <a href="Assets/ALGORITHMS/ALGORITHM_4.png" class="deliverable-link" target="_blank">View PDF</a>
                 </div>
             </div>
 
@@ -360,56 +360,56 @@
                 <div class="deliverables-grid">
                     <div class="deliverable-card">
                         <h3>UI Mockup 1</h3>
-                        <img src="Assets/UI_MOCKUPS_1.png" alt="UI Mockup 1" class="deliverable-image">
-                        <a href="Assets/UI_MOCKUPS_1.png" class="deliverable-link" target="_blank">View PDF</a>
+                        <img src="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_1.png" alt="UI Mockup 1" class="deliverable-image">
+                        <a href="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_1.png" class="deliverable-link" target="_blank">View PDF</a>
                     </div>
 
                     <div class="deliverable-card">
                         <h3>UI Mockup 2</h3>
-                        <img src="Assets/UI_MOCKUPS_2.png" alt="UI Mockup 2" class="deliverable-image">
-                        <a href="Assets/UI_MOCKUPS_2.png" class="deliverable-link" target="_blank">View PDF</a>
+                        <img src="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_2.png" alt="UI Mockup 2" class="deliverable-image">
+                        <a href="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_2.png" class="deliverable-link" target="_blank">View PDF</a>
                     </div>
 
                     <div class="deliverable-card">
                         <h3>UI Mockup 3</h3>
-                        <img src="Assets/UI_MOCKUPS_3.png" alt="UI Mockup 3" class="deliverable-image">
-                        <a href="Assets/UI_MOCKUPS_3.png" class="deliverable-link" target="_blank">View PDF</a>
+                        <img src="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_3.png" alt="UI Mockup 3" class="deliverable-image">
+                        <a href="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_3.png" class="deliverable-link" target="_blank">View PDF</a>
                     </div>
 
                     <div class="deliverable-card">
                         <h3>UI Mockup 4</h3>
-                        <img src="Assets/UI_MOCKUPS_4.png" alt="UI Mockup 4" class="deliverable-image">
-                        <a href="Assets/UI_MOCKUPS_4.png" class="deliverable-link" target="_blank">View PDF</a>
+                        <img src="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_4.png" alt="UI Mockup 4" class="deliverable-image">
+                        <a href="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_4.png" class="deliverable-link" target="_blank">View PDF</a>
                     </div>
 
                     <div class="deliverable-card">
                         <h3>UI Mockup 5</h3>
-                        <img src="Assets/UI_MOCKUPS_5.png" alt="UI Mockup 5" class="deliverable-image">
-                        <a href="Assets/UI_MOCKUPS_5.png" class="deliverable-link" target="_blank">View PDF</a>
+                        <img src="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_5.png" alt="UI Mockup 5" class="deliverable-image">
+                        <a href="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_5.png" class="deliverable-link" target="_blank">View PDF</a>
                     </div>
 
                     <div class="deliverable-card">
                         <h3>UI Mockup 6</h3>
-                        <img src="Assets/UI_MOCKUPS_6.png" alt="UI Mockup 6" class="deliverable-image">
-                        <a href="Assets/UI_MOCKUPS_6.png" class="deliverable-link" target="_blank">View PDF</a>
+                        <img src="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_6.png" alt="UI Mockup 6" class="deliverable-image">
+                        <a href="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_6.png" class="deliverable-link" target="_blank">View PDF</a>
                     </div>
 
                     <div class="deliverable-card">
                         <h3>UI Mockup 7</h3>
-                        <img src="Assets/UI_MOCKUPS_7.png" alt="UI Mockup 7" class="deliverable-image">
-                        <a href="Assets/UI_MOCKUPS_7.png" class="deliverable-link" target="_blank">View PDF</a>
+                        <img src="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_7.png" alt="UI Mockup 7" class="deliverable-image">
+                        <a href="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_7.png" class="deliverable-link" target="_blank">View PDF</a>
                     </div>
 
                     <div class="deliverable-card">
                         <h3>UI Mockup 8</h3>
-                        <img src="Assets/UI_MOCKUPS_8.png" alt="UI Mockup 8" class="deliverable-image">
-                        <a href="Assets/UI_MOCKUPS_8.png" class="deliverable-link" target="_blank">View PDF</a>
+                        <img src="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_8.png" alt="UI Mockup 8" class="deliverable-image">
+                        <a href="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_8.png" class="deliverable-link" target="_blank">View PDF</a>
                     </div>
 
                     <div class="deliverable-card">
                         <h3>UI Mockup 9</h3>
-                        <img src="Assets/UI_MOCKUPS_9.png" alt="UI Mockup 9" class="deliverable-image">
-                        <a href="Assets/UI_MOCKUPS_9.png" class="deliverable-link" target="_blank">View PDF</a>
+                        <img src="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_9.png" alt="UI Mockup 9" class="deliverable-image">
+                        <a href="Assets/UI_MOCKUPS_FALL_2025_OLD/UI_MOCKUPS_9.png" class="deliverable-link" target="_blank">View PDF</a>
                     </div>
 
 


### PR DESCRIPTION
Fix deliverables image rendering by updating broken asset paths in index.html.
Updates moved files to their current folders (RISKS_SLIDES, 410_FEATURE_TABLES_OLD, WORK_BREAKDOWN_STRUCTURE, ALGORITHMS, UI_MOCKUPS_FALL_2025_OLD).